### PR TITLE
fix wrong error format

### DIFF
--- a/webauth/index.js
+++ b/webauth/index.js
@@ -78,8 +78,12 @@ export default class WebAuth {
             const {
               code,
               state: resultState,
-              error
+              error,
+              error_description
             } = query;
+            if (error_description) {
+              throw new AuthError({json: query, status: 0});
+            }
             if (error) {
               throw new Auth0Error({json: query, status: 0});
             }


### PR DESCRIPTION
`webauth##authorize` does not parse errors returned from the API correctly which results in `Error: unknown error` messages. Instead, whenever the `error_description` field is available, it should use `AuthError` rather than `Auth0Error`.